### PR TITLE
Add flag to display temperature in Fahrenheit

### DIFF
--- a/co2meter/templates/index.html
+++ b/co2meter/templates/index.html
@@ -24,7 +24,7 @@
     <font size="+2">
       {{ timestamp }}
       <br>CO2 concentration: <font color="{{ color }}">{{ co2 }} ppm</font>
-      <br>Temperature: {{ temp }}&#8451;
+      <br>Temperature: {{ temp }}{{ degrees|safe }}
     </font>
   <br><br><a href="/log">Data log</a>
   (<a href="/log.csv">csv</a>,&nbsp;<a href="/log.json">json</a>)


### PR DESCRIPTION
This adds a new flag (-F or --fahrenheit) to display the temperature in Fahrenheit on the home page and dashboard.  All logs are still in Celsius for consistency.

![image](https://user-images.githubusercontent.com/2019044/79054870-633b6280-7bfd-11ea-86fb-942b1f456594.png)

![image](https://user-images.githubusercontent.com/2019044/79054946-0a1ffe80-7bfe-11ea-9857-f3d98e26e3aa.png)

